### PR TITLE
Dependabot renovate automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -46,11 +46,12 @@ jobs:
           # Use REST API -- it returns login as "renovate[bot]" / "dependabot[bot]"
           # (GraphQL via `gh pr list` returns "app/renovate" which is different)
           prs="$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
-            --jq "[.[] | select(
-              (.user.login==\"dependabot[bot]\" or .user.login==\"renovate[bot]\")
-              and .head.ref != \"$ROLLUP_BRANCH\"
-            ) | {number, branch: .head.ref}]")"
+            \"repos/${{ github.repository }}/pulls?state=open&per_page=100\" \
+            --arg rollup \"$ROLLUP_BRANCH\" \
+            --jq '[.[] | select(
+              (.user.login == \"dependabot[bot]\" or .user.login == \"renovate[bot]\")
+              and .head.ref != $rollup
+            ) | {number, branch: .head.ref}]')"
 
           count="$(echo "$prs" | jq 'length')"
           echo "Found $count open dependency PR(s)."


### PR DESCRIPTION
Fix the Dependabot/Renovate auto-merge action to correctly rollup and merge PRs.

The previous action failed due to author login mismatches, `GITHUB_TOKEN` permission issues for PR creation, and missing rollup logic. This PR restores the full rollup functionality, uses the REST API for correct bot author detection, and implements a PAT-first token strategy to bypass `GITHUB_TOKEN` limitations.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-79093a32-fa35-4874-b0c8-90e49fb2ff42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79093a32-fa35-4874-b0c8-90e49fb2ff42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

