### PR TITLE
🧹 [Code Health] Fix unused import in llm_core providers

### DIFF
--- a/packages/llm-core/src/affine/llm_core/providers/__init__.py
+++ b/packages/llm-core/src/affine/llm_core/providers/__init__.py
@@ -5,4 +5,5 @@ from affine.llm_core.providers.openai_compatible import OpenAICompatibleProvider
 __all__ = [
     "GeminiProvider",
     "AnthropicProvider",
+    "OpenAICompatibleProvider",
 ]


### PR DESCRIPTION
🎯 **What:** Added `OpenAICompatibleProvider` to `__all__` in `packages/llm-core/src/affine/llm_core/providers/__init__.py`.
💡 **Why:** This resolves an unused import warning from ruff by properly exporting the provider, making the module's public API more explicit.
✅ **Verification:** Verified with `uv run ruff check .` (which now passes cleanly) and `uv run pytest packages/llm-core` (which continues to pass 5/5 tests).
✨ **Result:** Cleaner code without an unused import warning, maintaining consistency and clarity in module exports.

---
*PR created automatically by Jules for task [17192911688780217451](https://jules.google.com/task/17192911688780217451) started by @Ven0m0*