### PR TITLE
🧹 Improve error handling in Editor image upload

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -118,8 +118,7 @@ export const Editor: React.FC = () => {
       }
       return urls
     } catch (e) {
-      console.error('Image upload failed', e)
-      return
+      throw new Error(`Image upload failed: ${e instanceof Error ? e.message : String(e)}`)
     }
   }
 


### PR DESCRIPTION
🎯 What: Replaced a `console.error` inside the `uploadImagesToRepo` catch block with `throw new Error(...)` in `apps/web/src/components/Editor.tsx`.
💡 Why: Previously, errors during image uploading were silently logged to the console and a void return bypassed upstream error propagation. The calling code (`imagePasteDrop.ts`) already wraps the call in a try/catch and is designed to gracefully fallback to data URLs if the repository upload fails. By throwing an error, the code correctly bubbles up the failure to the upstream error-handling logic instead of silently suppressing it, improving system robustness and maintainability.
✅ Verification: Ran `bun run lint` and `bun run typecheck` within `apps/web/`. Confirmed no new errors were introduced by the change.
✨ Result: Proper error bubbling now correctly integrates with the upstream caller's gracefully degraded fallback logic.

---
*PR created automatically by Jules for task [3196346012860606933](https://jules.google.com/task/3196346012860606933) started by @Ven0m0*