### PR TITLE
🔒 Fix overly permissive default CORS policy

### DIFF
--- a/packages/config/src/affine/config/settings.py
+++ b/packages/config/src/affine/config/settings.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     kilo_base_url: str = "https://api.kilo.ai/api/gateway"
     host: str = "0.0.0.0"
     port: int = 9000
-    cors_allow_origins: list[str] = ["*"]
+    cors_allow_origins: list[str] = []
     frontend_dist_dir: Path = Path("apps/web/dist")
     repo_index_enabled: bool = True
     repo_index_db_path: Path = Path(".cache/repo-index.db")
@@ -46,13 +46,13 @@ class Settings(BaseSettings):
             if not all(isinstance(origin, str) for origin in value):
                 raise ValueError("CORS origins must be strings.")
             origins = [origin.strip() for origin in value if origin.strip()]
-            return origins or ["*"]
+            return origins
 
         if not isinstance(value, str):
             return value
 
         origins = [origin.strip() for origin in value.split(",") if origin.strip()]
-        return origins or ["*"]
+        return origins
 
     def provider_api_key(self) -> str | None:
         if self.model_provider == "anthropic":

--- a/packages/config/tests/test_settings.py
+++ b/packages/config/tests/test_settings.py
@@ -59,3 +59,13 @@ def test_settings_validate_list_cors_origins() -> None:
 
     with pytest.raises(ValueError, match="CORS origins must be strings"):
         Settings(cors_allow_origins=[1])  # type: ignore[list-item]
+
+
+def test_settings_default_cors_origins() -> None:
+    settings = Settings()
+    assert settings.cors_allow_origins == []
+
+
+def test_settings_empty_cors_origins() -> None:
+    settings = Settings(cors_allow_origins=["", " "])
+    assert settings.cors_allow_origins == []


### PR DESCRIPTION
**🎯 What:**
The default value for `cors_allow_origins` in `packages/config/src/affine/config/settings.py` was a wildcard (`["*"]`). This has been changed to default to an empty list (`[]`). The parsing fallback behavior has also been updated to return an empty list instead of reverting to `["*"]` when an empty list or empty strings are configured. Two tests were added to `packages/config/tests/test_settings.py` to ensure this behavior is covered.

**⚠️ Risk:**
An overly permissive CORS policy allows arbitrary origins to make authenticated API requests to the server on the user's behalf. Given the application passes `allow_credentials=True` into `CORSMiddleware`, a default wildcard allows malicious websites to hijack authenticated user sessions via Cross-Site Request Forgery (CSRF) and access sensitive internal states.

**🛡️ Solution:**
By default, the CORS policy is now tightly restricted (an empty list means no CORS requests are allowed). Users are required to explicitly configure the trusted origins they expect frontend applications to connect from. This adheres to the principle of "secure by default" without impacting applications explicitly configured via environment variables.

---
*PR created automatically by Jules for task [11593834180496591516](https://jules.google.com/task/11593834180496591516) started by @Ven0m0*