### PR TITLE
fix(web): properly fix single quotes to double quotes in JSON healer

### DIFF
--- a/apps/web/src/utils/jsonHealer.ts
+++ b/apps/web/src/utils/jsonHealer.ts
@@ -201,33 +201,43 @@ export class JSONHealer {
   private static fixQuotes(input: string): string {
     // This is tricky as we need to avoid replacing single quotes inside double-quoted strings
     // Simple approach: replace single quotes with double quotes for keys and string values
-    const result = input
     let inString = false
     let quoteChar = ''
     let fixed = ''
 
-    for (let i = 0; i < result.length; i++) {
-      const char = result[i]
-      const prevChar = i > 0 ? result[i - 1] : ''
+    let i = 0
+    while (i < input.length) {
+      const char = input[i]
 
-      if ((char === '"' || char === "'") && prevChar !== '\\') {
-        if (!inString) {
-          // Starting a string
-          inString = true
-          quoteChar = char
-          fixed += '"'
-        } else if (char === quoteChar) {
-          // Ending a string
-          inString = false
-          quoteChar = ''
-          fixed += '"'
-        } else {
-          // Quote inside string
-          fixed += char
+      if (char === '\\') {
+        if (i + 1 < input.length) {
+          const nextChar = input[i + 1]
+          // If we are in a single quoted string and see an escaped single quote, unescape it
+          if (inString && quoteChar === "'" && nextChar === "'") {
+            fixed += "'"
+            i += 2
+            continue
+          }
+          fixed += char + nextChar
+          i += 2
+          continue
         }
+      }
+
+      if (!inString && (char === '"' || char === "'")) {
+        inString = true
+        quoteChar = char
+        fixed += '"'
+      } else if (inString && char === quoteChar) {
+        inString = false
+        quoteChar = ''
+        fixed += '"'
+      } else if (inString && quoteChar === "'" && char === '"') {
+        fixed += '\\"'
       } else {
         fixed += char
       }
+      i++
     }
 
     return fixed

--- a/apps/web/src/utils/jsonHealer.ts
+++ b/apps/web/src/utils/jsonHealer.ts
@@ -218,6 +218,13 @@ export class JSONHealer {
             i += 2
             continue
           }
+          // If we are in a double quoted string and see an escaped single quote, unescape it
+          // because \' is not a valid JSON escape sequence
+          if (inString && quoteChar === '"' && nextChar === "'") {
+            fixed += "'"
+            i += 2
+            continue
+          }
           fixed += char + nextChar
           i += 2
           continue


### PR DESCRIPTION
Fixes an issue with `JSONHealer.fixQuotes` where nested quotes and escape sequences were not properly handled. The new implementation correctly:

- Converts unescaped single quotes representing string bounds into double quotes.
- Properly preserves single quotes embedded in single-quoted strings.
- Escapes double quotes inside single quoted strings to prevent JSON parse errors.
- Unescapes escaped single quotes since the output uses double quotes.

---
*PR created automatically by Jules for task [15782552971731649977](https://jules.google.com/task/15782552971731649977) started by @Ven0m0*