### PR TITLE
fix(web): correctly quote unquoted keys in JSON healer

### DIFF
--- a/apps/web/src/utils/jsonHealer.ts
+++ b/apps/web/src/utils/jsonHealer.ts
@@ -135,8 +135,17 @@ export class JSONHealer {
    * Output: {"name": "Eve", "age": 40}
    */
   private static fixUnquotedKeys(input: string): string {
-    // Match unquoted keys like: word: (but not inside quotes)
-    return input.replace(/(\{|,)\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":')
+    // Match strings first, then unquoted keys like: word: (but not inside quotes)
+    const regex = /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|([{,])(\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)(\s*):/g
+    return input.replace(
+      regex,
+      (match, stringMatch, prefix, spaceBefore, key, spaceAfter) => {
+        if (stringMatch) {
+          return stringMatch
+        }
+        return `${prefix}${spaceBefore}"${key}"${spaceAfter}:`
+      }
+    )
   }
 
   /**

--- a/apps/web/src/utils/jsonHealer.ts
+++ b/apps/web/src/utils/jsonHealer.ts
@@ -139,7 +139,7 @@ export class JSONHealer {
     const regex = /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|([{,])(\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)(\s*):/g
     return input.replace(
       regex,
-      (match, stringMatch, prefix, spaceBefore, key, spaceAfter) => {
+      (_match, stringMatch, prefix, spaceBefore, key, spaceAfter) => {
         if (stringMatch) {
           return stringMatch
         }


### PR DESCRIPTION
This PR updates `fixUnquotedKeys` in `apps/web/src/utils/jsonHealer.ts`. Previously, the regex used could incorrectly match patterns that happen to be inside string literals. I modified it by adding a non-capturing group that consumes double-quoted and single-quoted strings first. The string literals are preserved, while any actual unquoted key object structure is correctly wrapped in double quotes. This prevents the JSON parser from breaking on malformed, unquoted keys while leaving text unmodified.

---
*PR created automatically by Jules for task [11375325567627290158](https://jules.google.com/task/11375325567627290158) started by @Ven0m0*