### PR TITLE
fix(web): properly fix missing brackets in jsonHealer

### DIFF
--- a/apps/web/src/utils/jsonHealer.test.ts
+++ b/apps/web/src/utils/jsonHealer.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { healJSON } from './jsonHealer';
+
+describe('JSONHealer', () => {
+  it('should fix missing brackets', () => {
+    const res1 = healJSON('{"a": [1, 2');
+    expect(res1.data).toEqual({ a: [1, 2] });
+
+    const res2 = healJSON('[{"a": 1');
+    expect(res2.data).toEqual([{ a: 1 }]);
+
+    // Testing unescaped strings or strings with brackets inside
+    const res3 = healJSON('{"a": "hello{world"');
+    expect(res3.data).toEqual({ a: "hello{world" });
+  });
+});

--- a/apps/web/src/utils/jsonHealer.test.ts
+++ b/apps/web/src/utils/jsonHealer.test.ts
@@ -11,6 +11,6 @@ describe('JSONHealer', () => {
 
     // Testing unescaped strings or strings with brackets inside
     const res3 = healJSON('{"a": "hello{world"');
-    expect(res3.data).toEqual({ a: "hello{world" });
+    expect(res3.data).toEqual({ a: 'hello{world' });
   });
 });

--- a/apps/web/src/utils/jsonHealer.ts
+++ b/apps/web/src/utils/jsonHealer.ts
@@ -158,21 +158,43 @@ export class JSONHealer {
    */
   private static fixMissingBrackets(input: string): string {
     let result = input.trim()
+    const stack: string[] = []
+    let inString = false
+    let i = 0
 
-    // Count opening and closing brackets
-    const openBraces = (result.match(/\{/g) || []).length
-    const closeBraces = (result.match(/\}/g) || []).length
-    const openBrackets = (result.match(/\[/g) || []).length
-    const closeBrackets = (result.match(/\]/g) || []).length
+    while (i < result.length) {
+      const ch = result[i]
 
-    // Add missing closing braces
-    for (let i = 0; i < openBraces - closeBraces; i++) {
-      result += '}'
+      if (inString) {
+        if (ch === '\\') {
+          i += 2
+          continue
+        }
+        if (ch === '"') {
+          inString = false
+        }
+      } else {
+        if (ch === '"') {
+          inString = true
+        } else if (ch === '{' || ch === '[') {
+          stack.push(ch)
+        } else if (ch === '}' || ch === ']') {
+          if (stack.length > 0) {
+            const last = stack[stack.length - 1]
+            if ((ch === '}' && last === '{') || (ch === ']' && last === '[')) {
+              stack.pop()
+            }
+          }
+        }
+      }
+      i++
     }
 
-    // Add missing closing brackets
-    for (let i = 0; i < openBrackets - closeBrackets; i++) {
-      result += ']'
+    // Reverse the stack and append corresponding closing brackets
+    while (stack.length > 0) {
+      const open = stack.pop()
+      if (open === '{') result += '}'
+      if (open === '[') result += ']'
     }
 
     return result


### PR DESCRIPTION
Replaces the naive regex counter in `fixMissingBrackets` with a robust stack-based algorithm. The new implementation correctly handles nesting order and intelligently ignores bracket characters that appear inside strings (by properly tracking `inString` state). Added unit tests in `jsonHealer.test.ts` to verify the logic.

---
*PR created automatically by Jules for task [10769265133175438689](https://jules.google.com/task/10769265133175438689) started by @Ven0m0*