### PR TITLE
⚡ [perf] load directories concurrently on tree expansion

### DIFF
--- a/apps/web/src/components/Tool.tsx
+++ b/apps/web/src/components/Tool.tsx
@@ -222,11 +222,11 @@ export const Tool: React.FC = () => {
     if (!path || !githubService) return
 
     const directories = getAncestorDirectories(path)
-    for (const directory of directories) {
-      if (!directoryEntries[directory]) {
-        await loadDirectory(directory, { silent: true })
-      }
-    }
+    const directoriesToLoad = directories.filter((dir) => !directoryEntries[dir])
+
+    await Promise.all(
+      directoriesToLoad.map((dir) => loadDirectory(dir, { silent: true }))
+    )
 
     setExpandedDirectories((prev) => Array.from(new Set([...prev, ...directories])))
   }, [directoryEntries, githubService, loadDirectory])


### PR DESCRIPTION
💡 **What:** Replaced the sequential `for` loop in `ensureTreePathVisible` (in `apps/web/src/components/Tool.tsx`) with a concurrent fetch using `Promise.all`. The optimization maps missing directories to `loadDirectory` promises and awaits them together.

🎯 **Why:** The previous logic awaited each directory load sequentially, meaning a deeply nested path expansion blocked the UI from loading further nodes until each parent finished loading. Using concurrent network requests cuts the total load time considerably as the GitHub API and internal app logic permits direct access and safe independent state update for directory components.

📊 **Measured Improvement:**
Before the changes, a mock sequential loading task simulating four depth levels (100ms latency each) took `~400ms`.
After introducing concurrency, the same benchmark took `~100ms`. This demonstrates a ~75% speedup directly correlated to directory depth. Network delay for sequential requests creates substantial UX latency, which this effectively mitigates.

---
*PR created automatically by Jules for task [13771843923494399838](https://jules.google.com/task/13771843923494399838) started by @Ven0m0*