### PR TITLE
🧹 Refactor duplicate embedder selection logic

### DIFF
--- a/apps/api/src/affine/api/local_index.py
+++ b/apps/api/src/affine/api/local_index.py
@@ -11,8 +11,8 @@ from affine.code_index import (
     CodeIndexer,
     CodeSearchEngine,
     CodeIndexStore,
-    EmbedderFactory,
 )
+from affine.api.utils import create_local_embedder
 from affine.config.settings import Settings, get_settings
 
 router = APIRouter(prefix="/v1/local-index", tags=["local-index"])
@@ -20,25 +20,13 @@ router = APIRouter(prefix="/v1/local-index", tags=["local-index"])
 
 def get_embedder(settings: Settings):
     """Factory for embedder based on settings."""
-    provider = settings.model_provider
-    api_key = settings.provider_api_key()
-    base_url = settings.provider_base_url()
-
-    if provider == "gemini" and settings.google_api_key:
-        return EmbedderFactory.create(
-            provider="gemini",
-            api_key=settings.google_api_key,
-        )
-    elif api_key:
-        return EmbedderFactory.create(
-            provider="openai",
-            api_key=api_key,
-            base_url=base_url,
-        )
-    raise HTTPException(
-        status_code=500,
-        detail="No API key configured for embeddings",
-    )
+    try:
+        return create_local_embedder(settings)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=str(exc),
+        ) from exc
 
 
 class LocalIndexRequest(BaseModel):

--- a/apps/api/src/affine/api/local_index_cli.py
+++ b/apps/api/src/affine/api/local_index_cli.py
@@ -11,8 +11,8 @@ from affine.code_index import (
     CodeIndexer,
     CodeSearchEngine,
     CodeIndexStore,
-    EmbedderFactory,
 )
+from affine.api.utils import create_local_embedder
 from affine.config.settings import get_settings
 
 
@@ -21,23 +21,10 @@ async def index_command(args: argparse.Namespace) -> int:
     settings = get_settings()
 
     # Select embedder based on settings
-    provider = settings.model_provider
-    api_key = settings.provider_api_key()
-    base_url = settings.provider_base_url()
-
-    if provider == "gemini" and settings.google_api_key:
-        embedder = EmbedderFactory.create(
-            provider="gemini",
-            api_key=settings.google_api_key,
-        )
-    elif api_key:
-        embedder = EmbedderFactory.create(
-            provider="openai",
-            api_key=api_key,
-            base_url=base_url,
-        )
-    else:
-        print("Error: No API key configured for embedding", file=sys.stderr)
+    try:
+        embedder = create_local_embedder(settings)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
 
     root = Path(args.root or ".").resolve()
@@ -71,23 +58,10 @@ async def search_command(args: argparse.Namespace) -> int:
     settings = get_settings()
 
     # Same embedder selection as index
-    provider = settings.model_provider
-    api_key = settings.provider_api_key()
-    base_url = settings.provider_base_url()
-
-    if provider == "gemini" and settings.google_api_key:
-        embedder = EmbedderFactory.create(
-            provider="gemini",
-            api_key=settings.google_api_key,
-        )
-    elif api_key:
-        embedder = EmbedderFactory.create(
-            provider="openai",
-            api_key=api_key,
-            base_url=base_url,
-        )
-    else:
-        print("Error: No API key configured for embedding", file=sys.stderr)
+    try:
+        embedder = create_local_embedder(settings)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
 
     db_path = Path(args.db or ".index/lancedb").resolve()
@@ -125,15 +99,11 @@ async def stats_command(args: argparse.Namespace) -> int:
     settings = get_settings()
 
     # Need an embedder just to get dimension
-    api_key = settings.provider_api_key()
-    if not api_key:
-        print("Error: No API key configured", file=sys.stderr)
+    try:
+        embedder = create_local_embedder(settings)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
-
-    embedder = EmbedderFactory.create(
-        provider="openai" if settings.model_provider != "gemini" else "gemini",
-        api_key=api_key or settings.google_api_key or "",
-    )
 
     db_path = Path(args.db or ".index/lancedb").resolve()
 

--- a/apps/api/src/affine/api/utils.py
+++ b/apps/api/src/affine/api/utils.py
@@ -1,0 +1,27 @@
+"""Utility functions for Affine API."""
+
+from __future__ import annotations
+
+from affine.code_index import Embedder, EmbedderFactory
+from affine.config.settings import Settings
+
+
+def create_local_embedder(settings: Settings) -> Embedder:
+    """Factory for creating an embedder based on application settings."""
+    provider = settings.model_provider
+    api_key = settings.provider_api_key()
+    base_url = settings.provider_base_url()
+
+    if provider == "gemini" and settings.google_api_key:
+        return EmbedderFactory.create(
+            provider="gemini",
+            api_key=settings.google_api_key,
+        )
+    elif api_key:
+        return EmbedderFactory.create(
+            provider="openai",
+            api_key=api_key,
+            base_url=base_url,
+        )
+
+    raise ValueError("No API key configured for embedding")


### PR DESCRIPTION
The code health improvement addressed the issue of duplicated embedder selection logic in `apps/api/src/affine/api/local_index_cli.py` and `apps/api/src/affine/api/local_index.py`.

I have:
1. Created a shared utility `create_local_embedder(settings: Settings)` in `apps/api/src/affine/api/utils.py`.
2. Refactored `local_index.py` to use this shared utility, ensuring consistent error handling via `HTTPException`.
3. Refactored `local_index_cli.py` to use the utility in `index_command`, `search_command`, and `stats_command`, ensuring consistent error reporting to `stderr`.
4. Verified that all existing tests pass and that linting checks succeed.

This change reduces code duplication and makes it easier to add or modify embedding providers in the future.

---
*PR created automatically by Jules for task [15567542157224309655](https://jules.google.com/task/15567542157224309655) started by @Ven0m0*