### PR TITLE
🧪 [testing improvement] Add tests for OpenAI provider delta extraction

### DIFF
--- a/packages/llm-core/tests/test_openai_compatible_extraction.py
+++ b/packages/llm-core/tests/test_openai_compatible_extraction.py
@@ -1,0 +1,73 @@
+from affine.llm_core.providers.openai_compatible import OpenAICompatibleProvider
+
+def test_extract_message_text_string():
+    data = {
+        "choices": [
+            {"message": {"content": "hello world"}}
+        ]
+    }
+    assert OpenAICompatibleProvider._extract_message_text(data) == "hello world"
+
+def test_extract_message_text_list():
+    data = {
+        "choices": [
+            {"message": {"content": [{"text": "hello "}, {"text": "world"}]}}
+        ]
+    }
+    assert OpenAICompatibleProvider._extract_message_text(data) == "hello world"
+
+def test_extract_message_text_empty_choices():
+    data = {"choices": []}
+    assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
+def test_extract_message_text_missing_choices():
+    data = {}
+    assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
+def test_extract_message_text_missing_message():
+    data = {"choices": [{}]}
+    assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
+def test_extract_message_text_missing_content():
+    data = {"choices": [{"message": {}}]}
+    assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
+def test_extract_message_text_unexpected_content_type():
+    data = {"choices": [{"message": {"content": 123}}]}
+    assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
+def test_extract_delta_text_string():
+    data = {
+        "choices": [
+            {"delta": {"content": "hello delta"}}
+        ]
+    }
+    assert OpenAICompatibleProvider._extract_delta_text(data) == "hello delta"
+
+def test_extract_delta_text_list():
+    data = {
+        "choices": [
+            {"delta": {"content": [{"text": "hello "}, {"text": "delta"}]}}
+        ]
+    }
+    assert OpenAICompatibleProvider._extract_delta_text(data) == "hello delta"
+
+def test_extract_delta_text_empty_choices():
+    data = {"choices": []}
+    assert OpenAICompatibleProvider._extract_delta_text(data) == ""
+
+def test_extract_delta_text_missing_choices():
+    data = {}
+    assert OpenAICompatibleProvider._extract_delta_text(data) == ""
+
+def test_extract_delta_text_missing_delta():
+    data = {"choices": [{}]}
+    assert OpenAICompatibleProvider._extract_delta_text(data) == ""
+
+def test_extract_delta_text_missing_content():
+    data = {"choices": [{"delta": {}}]}
+    assert OpenAICompatibleProvider._extract_delta_text(data) == ""
+
+def test_extract_delta_text_unexpected_content_type():
+    data = {"choices": [{"delta": {"content": None}}]}
+    assert OpenAICompatibleProvider._extract_delta_text(data) == ""

--- a/packages/llm-core/tests/test_openai_compatible_extraction.py
+++ b/packages/llm-core/tests/test_openai_compatible_extraction.py
@@ -1,72 +1,74 @@
 from affine.llm_core.providers.openai_compatible import OpenAICompatibleProvider
 
+
 def test_extract_message_text_string():
-    data = {
-        "choices": [
-            {"message": {"content": "hello world"}}
-        ]
-    }
+    data = {"choices": [{"message": {"content": "hello world"}}]}
     assert OpenAICompatibleProvider._extract_message_text(data) == "hello world"
+
 
 def test_extract_message_text_list():
     data = {
-        "choices": [
-            {"message": {"content": [{"text": "hello "}, {"text": "world"}]}}
-        ]
+        "choices": [{"message": {"content": [{"text": "hello "}, {"text": "world"}]}}]
     }
     assert OpenAICompatibleProvider._extract_message_text(data) == "hello world"
+
 
 def test_extract_message_text_empty_choices():
     data = {"choices": []}
     assert OpenAICompatibleProvider._extract_message_text(data) == ""
 
+
 def test_extract_message_text_missing_choices():
     data = {}
     assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
 
 def test_extract_message_text_missing_message():
     data = {"choices": [{}]}
     assert OpenAICompatibleProvider._extract_message_text(data) == ""
 
+
 def test_extract_message_text_missing_content():
     data = {"choices": [{"message": {}}]}
     assert OpenAICompatibleProvider._extract_message_text(data) == ""
+
 
 def test_extract_message_text_unexpected_content_type():
     data = {"choices": [{"message": {"content": 123}}]}
     assert OpenAICompatibleProvider._extract_message_text(data) == ""
 
+
 def test_extract_delta_text_string():
-    data = {
-        "choices": [
-            {"delta": {"content": "hello delta"}}
-        ]
-    }
+    data = {"choices": [{"delta": {"content": "hello delta"}}]}
     assert OpenAICompatibleProvider._extract_delta_text(data) == "hello delta"
+
 
 def test_extract_delta_text_list():
     data = {
-        "choices": [
-            {"delta": {"content": [{"text": "hello "}, {"text": "delta"}]}}
-        ]
+        "choices": [{"delta": {"content": [{"text": "hello "}, {"text": "delta"}]}}]
     }
     assert OpenAICompatibleProvider._extract_delta_text(data) == "hello delta"
+
 
 def test_extract_delta_text_empty_choices():
     data = {"choices": []}
     assert OpenAICompatibleProvider._extract_delta_text(data) == ""
 
+
 def test_extract_delta_text_missing_choices():
     data = {}
     assert OpenAICompatibleProvider._extract_delta_text(data) == ""
+
 
 def test_extract_delta_text_missing_delta():
     data = {"choices": [{}]}
     assert OpenAICompatibleProvider._extract_delta_text(data) == ""
 
+
 def test_extract_delta_text_missing_content():
     data = {"choices": [{"delta": {}}]}
     assert OpenAICompatibleProvider._extract_delta_text(data) == ""
+
 
 def test_extract_delta_text_unexpected_content_type():
     data = {"choices": [{"delta": {"content": None}}]}


### PR DESCRIPTION
This PR addresses the missing test coverage for the `_extract_delta_text` function in the `OpenAICompatibleProvider`. It also includes tests for its sibling function `_extract_message_text`.

🎯 **What:** The testing gap addressed by adding unit tests for static extraction methods in `OpenAICompatibleProvider`.
📊 **Coverage:** 
- `_extract_delta_text`: string content, list content, empty choices, missing delta, missing content, unexpected type.
- `_extract_message_text`: string content, list content, empty choices, missing message, missing content, unexpected type.
✨ **Result:** Improved reliability and confidence in the content extraction logic for OpenAI-compatible providers.

---
*PR created automatically by Jules for task [16680200338984671178](https://jules.google.com/task/16680200338984671178) started by @Ven0m0*