### PR TITLE
🔒 Move sensitive credentials from LocalStorage to SessionStorage

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,7 +9,7 @@ import { InstallPrompt } from './components/InstallPrompt';
 import { ChatDemo } from './components/ChatDemo';
 import { OpenRouterChat } from './components/OpenRouterChat';
 import { AgentChat } from './components/AgentChat';
-import { migrateSavedConfig } from './services/providers';
+import { loadConfig } from './services/storage';
 import { readSavedShellState } from './services/shell';
 import './App.css';
 
@@ -159,14 +159,7 @@ function App() {
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', 'dark');
-    const savedConfig = localStorage.getItem('chat-github-config');
-    if (savedConfig) {
-      try {
-        setConfig(migrateSavedConfig(JSON.parse(savedConfig)));
-      } catch {
-        // silently ignore invalid config JSON in localStorage
-      }
-    }
+    setConfig(loadConfig(config));
     setShell(readSavedShellState());
   }, [setConfig, setShell]);
 

--- a/apps/web/src/components/ConfigOverlay.tsx
+++ b/apps/web/src/components/ConfigOverlay.tsx
@@ -8,6 +8,7 @@ import {
   migrateSavedConfig,
   type ProviderConfig,
 } from '../services/providers'
+import { clearStorage, hasSavedConfig, loadConfig, saveConfig } from '../services/storage'
 
 interface ConfigOverlayProps {
   /**
@@ -50,7 +51,7 @@ export const ConfigOverlay: React.FC<ConfigOverlayProps> = ({ inline = false }) 
   const [temperatureInput, setTemperatureInput] = useState(() => String(config.temperature))
   const [repoInput, setRepoInput] = useState(() => formatRepositoryInput(config.owner, config.repo))
   const [showTokens, setShowTokens] = useState(false)
-  const [rememberCredentials, setRememberCredentials] = useState(() => Boolean(localStorage.getItem('chat-github-config')))
+  const [rememberCredentials, setRememberCredentials] = useState(() => hasSavedConfig())
   /** Brief confirmation shown in inline mode after a successful save. */
   const [showSavedMessage, setShowSavedMessage] = useState(false)
   const [storageMessage, setStorageMessage] = useState<{ tone: 'success' | 'error'; text: string } | null>(null)
@@ -136,21 +137,7 @@ export const ConfigOverlay: React.FC<ConfigOverlayProps> = ({ inline = false }) 
     })
     setConfig(normalized)
 
-    if (rememberCredentials) {
-      localStorage.setItem('chat-github-config', JSON.stringify({
-        githubToken: normalized.githubToken,
-        openaiKey: normalized.openaiKey,
-        providers: normalized.providers,
-        provider: normalized.provider,
-        owner: normalized.owner,
-        repo: normalized.repo,
-        branch: normalized.branch,
-        model: normalized.model,
-        temperature: normalized.temperature,
-      }))
-    } else {
-      localStorage.removeItem('chat-github-config')
-    }
+    saveConfig(normalized, rememberCredentials)
 
     setStorageMessage({
       tone: 'success',
@@ -179,30 +166,26 @@ export const ConfigOverlay: React.FC<ConfigOverlayProps> = ({ inline = false }) 
   }
 
   const handleLoadFromStorage = () => {
-    const saved = localStorage.getItem('chat-github-config')
-    if (saved) {
+    if (hasSavedConfig()) {
       try {
-        const parsedConfig = migrateSavedConfig({
-          ...localConfig,
-          ...JSON.parse(saved),
-        })
-        setLocalConfig(parsedConfig)
-        setTemperatureInput(String(parsedConfig.temperature))
-        setRepoInput(formatRepositoryInput(parsedConfig.owner, parsedConfig.repo))
+        const loaded = loadConfig(localConfig)
+        setLocalConfig(loaded)
+        setTemperatureInput(String(loaded.temperature))
+        setRepoInput(formatRepositoryInput(loaded.owner, loaded.repo))
         setRememberCredentials(true)
-        setStorageMessage({ tone: 'success', text: 'Loaded saved configuration from local storage.' })
+        setStorageMessage({ tone: 'success', text: 'Loaded saved configuration from storage.' })
       } catch {
         setStorageMessage({ tone: 'error', text: 'Failed to load the saved configuration.' })
       }
     } else {
-      setStorageMessage({ tone: 'error', text: 'No saved configuration found in local storage.' })
+      setStorageMessage({ tone: 'error', text: 'No saved configuration found.' })
     }
   }
 
   const handleClearStorage = () => {
-    localStorage.removeItem('chat-github-config')
+    clearStorage()
     setRememberCredentials(false)
-    setStorageMessage({ tone: 'success', text: 'Cleared the saved configuration from local storage.' })
+    setStorageMessage({ tone: 'success', text: 'Cleared the saved configuration.' })
   }
 
   const availableModels = selectedProvider?.models ?? []
@@ -493,7 +476,7 @@ export const ConfigOverlay: React.FC<ConfigOverlayProps> = ({ inline = false }) 
               checked={rememberCredentials}
               onChange={(e) => setRememberCredentials(e.target.checked)}
             />
-            Remember credentials in local storage on this device
+            Remember configuration across sessions (sensitive tokens will only persist in the current session)
           </label>
         </div>
         <div className="config-field">

--- a/apps/web/src/services/storage.test.ts
+++ b/apps/web/src/services/storage.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sanitizeConfig, saveConfig, loadConfig, clearStorage } from './storage';
+import { ConfigState } from '../store';
+
+describe('storage service', () => {
+  const mockConfig: Partial<ConfigState> = {
+    githubToken: 'ghp_secret_token',
+    openaiKey: 'sk-openai-key',
+    owner: 'test-owner',
+    repo: 'test-repo',
+    providers: [
+      {
+        id: 'test-provider',
+        name: 'Test Provider',
+        apiKey: 'provider-secret-key',
+        baseUrl: 'https://api.test.com',
+        models: [{ id: 'test-model', name: 'Test Model' }],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    vi.stubGlobal('sessionStorage', {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  it('sanitizes sensitive fields', () => {
+    const sanitized = sanitizeConfig(mockConfig);
+    expect(sanitized.githubToken).toBe('');
+    expect(sanitized.openaiKey).toBe('');
+    expect(sanitized.providers?.[0].apiKey).toBe('');
+    expect(sanitized.owner).toBe('test-owner');
+  });
+
+  it('saveConfig stores full config in sessionStorage and sanitized in localStorage', () => {
+    saveConfig(mockConfig as ConfigState, true);
+
+    // Verify sessionStorage call (full config)
+    const sessionCall = vi.mocked(sessionStorage.setItem).mock.calls[0];
+    const sessionData = JSON.parse(sessionCall[1]);
+    expect(sessionData.githubToken).toBe('ghp_secret_token');
+    expect(sessionData.providers[0].apiKey).toBe('provider-secret-key');
+
+    // Verify localStorage call (sanitized config)
+    const localCall = vi.mocked(localStorage.setItem).mock.calls[0];
+    const localData = JSON.parse(localCall[1]);
+    expect(localData.githubToken).toBe('');
+    expect(localData.providers[0].apiKey).toBe('');
+    expect(localData.owner).toBe('test-owner');
+  });
+
+  it('loadConfig merges localStorage and sessionStorage', () => {
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify({
+      owner: 'test-owner',
+      githubToken: '',
+    }));
+    vi.mocked(sessionStorage.getItem).mockReturnValue(JSON.stringify({
+      githubToken: 'ghp_session_token',
+    }));
+
+    const loaded = loadConfig({} as ConfigState);
+    expect(loaded.owner).toBe('test-owner');
+    expect(loaded.githubToken).toBe('ghp_session_token');
+  });
+
+  it('clearStorage removes data from both storages', () => {
+    clearStorage();
+    expect(localStorage.removeItem).toHaveBeenCalledWith('chat-github-config');
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('chat-github-config');
+  });
+});

--- a/apps/web/src/services/storage.ts
+++ b/apps/web/src/services/storage.ts
@@ -1,0 +1,88 @@
+import type { ConfigState } from '../store';
+import { migrateSavedConfig } from './providers';
+
+const STORAGE_KEY = 'chat-github-config';
+
+/**
+ * Removes sensitive fields from a configuration object.
+ * Currently targeted at githubToken, openaiKey, and provider API keys.
+ */
+export function sanitizeConfig(config: Partial<ConfigState>): Partial<ConfigState> {
+  const sanitized = { ...config };
+
+  // Remove top-level sensitive fields
+  if ('githubToken' in sanitized) sanitized.githubToken = '';
+  if ('openaiKey' in sanitized) sanitized.openaiKey = '';
+
+  // Remove API keys from individual providers
+  if (sanitized.providers) {
+    sanitized.providers = sanitized.providers.map((p) => ({
+      ...p,
+      apiKey: '',
+    }));
+  }
+
+  return sanitized;
+}
+
+/**
+ * Persists the configuration to browser storage.
+ * - Full configuration (including tokens) is stored in sessionStorage.
+ * - If 'remember' is true, a sanitized version is stored in localStorage.
+ */
+export function saveConfig(config: Partial<ConfigState>, remember: boolean): void {
+  // Always store the full config in sessionStorage for the current session persistence (reloads)
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+
+  if (remember) {
+    // Store only the sanitized config in localStorage for cross-session remembrance of non-sensitive settings
+    const sanitized = sanitizeConfig(config);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitized));
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+/**
+ * Loads and merges configuration from localStorage and sessionStorage.
+ * Prioritizes sessionStorage to recover sensitive tokens for the current session.
+ */
+export function loadConfig(currentConfig: ConfigState): ConfigState {
+  const localRaw = localStorage.getItem(STORAGE_KEY);
+  const sessionRaw = sessionStorage.getItem(STORAGE_KEY);
+
+  let merged: any = { ...currentConfig };
+
+  if (localRaw) {
+    try {
+      merged = { ...merged, ...JSON.parse(localRaw) };
+    } catch {
+      // ignore invalid JSON
+    }
+  }
+
+  if (sessionRaw) {
+    try {
+      merged = { ...merged, ...JSON.parse(sessionRaw) };
+    } catch {
+      // ignore invalid JSON
+    }
+  }
+
+  return migrateSavedConfig(merged);
+}
+
+/**
+ * Clears saved configuration from both localStorage and sessionStorage.
+ */
+export function clearStorage(): void {
+  localStorage.removeItem(STORAGE_KEY);
+  sessionStorage.removeItem(STORAGE_KEY);
+}
+
+/**
+ * Checks if there is a configuration saved in localStorage.
+ */
+export function hasSavedConfig(): boolean {
+  return Boolean(localStorage.getItem(STORAGE_KEY));
+}


### PR DESCRIPTION
This PR fixes a security vulnerability where sensitive credentials (GitHub tokens, OpenAI keys, and provider API keys) were being stored in persistent `localStorage`. 

The fix involves:
- Implementing a `storage.ts` utility that sanitizes configuration objects before persisting to `localStorage`.
- Moving the primary storage for full configurations (including secrets) to `sessionStorage`.
- Updating the frontend to merge data from both storage locations on startup, prioritizing `sessionStorage` for secrets.
- Updating UI labels to accurately reflect the change in persistence.
- Adding comprehensive unit tests in `storage.test.ts`.

---
*PR created automatically by Jules for task [15289250624400287961](https://jules.google.com/task/15289250624400287961) started by @Ven0m0*