### PR TITLE
🔒 Security fix: Storing Sensitive Credentials in LocalStorage

### DIFF
--- a/apps/web/src/services/storage.ts
+++ b/apps/web/src/services/storage.ts
@@ -1,0 +1,63 @@
+import { ProviderConfig } from './providers';
+
+export interface StorageConfig {
+  githubToken?: string;
+  openaiKey?: string;
+  providers?: ProviderConfig[];
+  provider?: string;
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  model?: string;
+  temperature?: number;
+}
+
+export const CONFIG_KEY = 'chat-github-config';
+
+export function sanitizeConfig(config: StorageConfig): StorageConfig {
+  const sanitized = { ...config };
+  delete sanitized.githubToken;
+  delete sanitized.openaiKey;
+
+  if (sanitized.providers) {
+    sanitized.providers = sanitized.providers.map((p) => ({
+      ...p,
+      apiKey: '',
+    }));
+  }
+  return sanitized;
+}
+
+export function saveConfigToStorage(config: StorageConfig) {
+  // Store full config including credentials in tab-scoped sessionStorage
+  sessionStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+
+  // Persist only non-sensitive settings in localStorage
+  const safeConfig = sanitizeConfig(config);
+  localStorage.setItem(CONFIG_KEY, JSON.stringify(safeConfig));
+}
+
+export function loadConfigFromStorage(): StorageConfig | null {
+  // Try to load full config from sessionStorage first (current tab)
+  const sessionData = sessionStorage.getItem(CONFIG_KEY);
+  if (sessionData) {
+    try {
+      return JSON.parse(sessionData);
+    } catch {}
+  }
+
+  // Fallback to localStorage (new tab, sanitized config only)
+  const localData = localStorage.getItem(CONFIG_KEY);
+  if (localData) {
+    try {
+      return JSON.parse(localData);
+    } catch {}
+  }
+
+  return null;
+}
+
+export function clearConfigStorage() {
+  sessionStorage.removeItem(CONFIG_KEY);
+  localStorage.removeItem(CONFIG_KEY);
+}

--- a/apps/web/src/services/storage.ts
+++ b/apps/web/src/services/storage.ts
@@ -1,4 +1,4 @@
-import { ProviderConfig } from './providers';
+import type { ProviderConfig } from './providers';
 
 export interface StorageConfig {
   githubToken?: string;


### PR DESCRIPTION
🎯 **What:** Provider API keys and GitHub tokens were being saved in plaintext to localStorage when 'Remember credentials' was checked.

⚠️ **Risk:** Storing sensitive tokens in localStorage creates a vulnerability to Cross-Site Scripting (XSS) attacks. If an attacker injects a malicious script, they can steal these credentials.

🛡️ **Solution:** Implemented a dual-storage strategy. Sensitive credentials are now stored in tab-scoped sessionStorage, limiting their exposure, while non-sensitive settings are sanitized and saved to localStorage.

---
*PR created automatically by Jules for task [2984843176488341378](https://jules.google.com/task/2984843176488341378) started by @Ven0m0*