### PR TITLE
🔒 Fix API endpoints fail-open on missing configuration

### DIFF
--- a/apps/api/src/affine/api/server.py
+++ b/apps/api/src/affine/api/server.py
@@ -134,12 +134,11 @@ def verify_api_key(
     credentials: HTTPAuthorizationCredentials = Depends(security),
     settings: Settings = Depends(get_settings),
 ):
-    # If no server API key is configured operate in open/public mode so that
-    # users can authenticate only via their own provider keys in the request body.
-    # credentials may be None here (HTTPBearer auto_error=False) which is fine —
-    # the endpoint does not use the credentials object directly.
     if not settings.api_key:
-        return credentials
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Server API key is not configured",
+        )
     if not credentials or not secrets.compare_digest(
         credentials.credentials, settings.api_key
     ):

--- a/apps/api/tests/test_server.py
+++ b/apps/api/tests/test_server.py
@@ -98,21 +98,20 @@ def test_chat_completions_requires_auth_when_key_configured(
     assert resp.status_code == 401
 
 
-def test_chat_completions_open_mode_no_auth_required(
+def test_chat_completions_fails_closed_when_unconfigured(
     client_open: TestClient,
 ) -> None:
-    with patch("affine.api.server.ProviderFactory.create") as mock_create:
-        mock_create.return_value = _mock_provider("hi")
-        resp = client_open.post(
-            "/v1/chat/completions",
-            json={
-                "model": "gemini-3.1-pro-preview",
-                "messages": VALID_MESSAGES,
-                "x_provider": "gemini",
-                "x_provider_api_key": "user-gemini-key",
-            },
-        )
-    assert resp.status_code == 200
+    resp = client_open.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gemini-3.1-pro-preview",
+            "messages": VALID_MESSAGES,
+            "x_provider": "gemini",
+            "x_provider_api_key": "user-gemini-key",
+        },
+    )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Server API key is not configured"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### 🎯 What:
The `verify_api_key` function in `apps/api/src/affine/api/server.py` was allowing unauthorized access when the server API key (`settings.api_key`) was not configured. It acted as a fail-open mechanism and bypassed authentication, putting the endpoints at risk of unauthorized access.

### ⚠️ Risk:
If the `api_key` configuration was accidentally omitted or misconfigured on the server, the API endpoints would become publicly accessible without any authentication. This could lead to unauthorized data access, misuse of APIs, and potential exploitation of the backend services, bypassing the intended security controls.

### 🛡️ Solution:
Modified `verify_api_key` to strictly enforce authorization. If the `settings.api_key` is missing or not configured, it now raises an HTTP 500 Internal Server Error explicitly, adhering to a fail-closed security posture. This ensures that the application securely denies access when proper configuration is absent rather than falling back to an open mode. The corresponding test was also updated to verify this fail-closed behavior.

---
*PR created automatically by Jules for task [11354781269679233412](https://jules.google.com/task/11354781269679233412) started by @Ven0m0*