### PR TITLE
🔒 [security] Fix potential XSS via SVG data URLs in image preview

### DIFF
--- a/apps/web/src/codemirror/imagePreview.test.ts
+++ b/apps/web/src/codemirror/imagePreview.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeSrc } from './imagePreview';
+
+describe('isSafeSrc', () => {
+  it('should allow standard http/https URLs', () => {
+    expect(isSafeSrc('http://example.com/image.png')).toBe(true);
+    expect(isSafeSrc('https://example.com/image.png')).toBe(true);
+  });
+
+  it('should allow relative paths', () => {
+    expect(isSafeSrc('/path/to/image.png')).toBe(true);
+    expect(isSafeSrc('image.png')).toBe(true);
+    expect(isSafeSrc('./image.png')).toBe(true);
+    expect(isSafeSrc('../image.png')).toBe(true);
+  });
+
+  it('should allow safe data URLs', () => {
+    expect(isSafeSrc('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==')).toBe(true);
+    expect(isSafeSrc('data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFgEBAQEAAAAAAAAAAAAAAAAAAAEC/8QAFREBAQAAAAAAAAAAAAAAAAAAABH/2gAMA4EAAII')).toBe(true);
+    expect(isSafeSrc('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7')).toBe(true);
+    expect(isSafeSrc('data:image/webp;base64,UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA=')).toBe(true);
+    expect(isSafeSrc('data:image/avif,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZgAAAAltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABwaWN0AAAAAAAAAAAAAAAAAAAAAA5waXRtAAAAAAABAAAAF2lsb2MAAAAAREAAAQABAAAAAAEOAAEAAAAAaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAMYXYwQzEwMAAAAABhdmFzAAAAAAAAABhhdjFj+EAsAgSgBQAAABNjb2xybmNseAABAAEAAYAAAAAYaXBycAAAAEphc3BjAAAAAAAAAAEAAGF1eGMAAAAAAAAAAQAAABNjb2xybmNseAABAAEAAYAAAAAbaXBtYQAAAAAAAAABAAEBAgGCAAAAAWJwaXhlbAAAAA1pc29wAAAAAAAAAAo=')).toBe(true);
+  });
+
+  it('should block dangerous data URLs', () => {
+    // This is the current vulnerability: SVG is allowed
+    // We expect it to return FALSE eventually, but for reproduction it currently returns TRUE
+    // I will write the test to expect FALSE so it FAILS now, confirming the vulnerability.
+    expect(isSafeSrc('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxzY3JpcHQ+YWxlcnQoMSk8L3NjcmlwdD48L3N2Zz4=')).toBe(false);
+    expect(isSafeSrc('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('should block dangerous schemes', () => {
+    expect(isSafeSrc('javascript:alert(1)')).toBe(false);
+    expect(isSafeSrc('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeSrc('data:text/javascript,alert(1)')).toBe(false);
+  });
+
+  it('should block cases with whitespace or mixed case', () => {
+    expect(isSafeSrc('   javascript:alert(1)')).toBe(false);
+    expect(isSafeSrc('JAVASCRIPT:alert(1)')).toBe(false);
+    expect(isSafeSrc('data:image/svg+xml;utf8,<svg></svg>')).toBe(false);
+  });
+});

--- a/apps/web/src/codemirror/imagePreview.ts
+++ b/apps/web/src/codemirror/imagePreview.ts
@@ -5,15 +5,33 @@ import { Decoration, EditorView, ViewPlugin, ViewUpdate, WidgetType } from '@cod
 type ImgRef = { alt: string; src: string };
 
 // Simple sanitizer: allow http(s), safe data:image URLs, or relative paths; block javascript:/vbscript:/data: URIs
-function isSafeSrc(src: string): boolean {
+export function isSafeSrc(src: string): boolean {
   const trimmed = src.trim();
   const lower = trimmed.toLowerCase();
-  // Only allow data URLs that are clearly images
-  if (lower.startsWith('data:image/')) return true;
-  // Block scripting or generic data schemes regardless of casing/whitespace
-  if (['javascript:', 'vbscript:', 'data:'].some((scheme) => lower.startsWith(scheme))) return false;
+
+  // Block known dangerous schemes
+  if (['javascript:', 'vbscript:'].some((scheme) => lower.startsWith(scheme))) return false;
+
+  // For data: URLs, only allow specific safe image MIME types (no SVG)
+  if (lower.startsWith('data:')) {
+    const safeImageMimes = [
+      'image/png',
+      'image/jpeg',
+      'image/jpg',
+      'image/gif',
+      'image/webp',
+      'image/avif',
+      'image/apng',
+    ];
+    return safeImageMimes.some(
+      (mime) => lower.startsWith(`data:${mime};`) || lower.startsWith(`data:${mime},`)
+    );
+  }
+
   // Allow standard http(s) URLs
   if (['http://', 'https://'].some((scheme) => lower.startsWith(scheme))) return true;
+
+  // Allow relative paths or same-origin paths
   return trimmed.startsWith('/') || !trimmed.includes('://');
 }
 


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in the image preview logic where `data:image/svg+xml` URLs were permitted.
⚠️ **Risk:** SVG images can contain embedded scripts (`<script>` tags) or event handlers that execute in the context of the application when rendered or opened, leading to Cross-Site Scripting (XSS).
🛡️ **Solution:** Modified `isSafeSrc` in `apps/web/src/codemirror/imagePreview.ts` to use a strict allow-list for `data:` URIs. It now only permits safe bitmap formats (PNG, JPEG, GIF, WebP, AVIF, APNG) and explicitly blocks SVG and other executable types. Standard `http/https` and relative URLs remain supported. Added comprehensive unit tests to verify the fix.

---
*PR created automatically by Jules for task [5975840869113990410](https://jules.google.com/task/5975840869113990410) started by @Ven0m0*