### PR TITLE
🧪 Add unit tests for `normalize_l2` math function

### DIFF
--- a/packages/code-index/tests/conftest.py
+++ b/packages/code-index/tests/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "shared/python/src"))
+sys.path.insert(0, str(ROOT / "config/src"))
+sys.path.insert(0, str(ROOT / "llm-core/src"))
+sys.path.insert(0, str(ROOT / "code-index/src"))

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -1,0 +1,31 @@
+import numpy as np
+from affine.code_index.embedder import normalize_l2
+
+
+def test_normalize_l2():
+    # Test with standard vectors
+    vectors = np.array([[3.0, 4.0], [1.0, 1.0], [0.0, 5.0]])
+    normalized = normalize_l2(vectors)
+
+    # Check shape
+    assert normalized.shape == vectors.shape
+
+    # Check that norms are 1
+    norms = np.linalg.norm(normalized, axis=1)
+    np.testing.assert_allclose(norms, np.ones(3), rtol=1e-5)
+
+    # Check specific values
+    expected = np.array([[0.6, 0.8], [1 / np.sqrt(2), 1 / np.sqrt(2)], [0.0, 1.0]])
+    np.testing.assert_allclose(normalized, expected, rtol=1e-5)
+
+
+def test_normalize_l2_zero_vector():
+    # Test with zero vector
+    vectors = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    normalized = normalize_l2(vectors)
+
+    # Check zero vector remains zero
+    np.testing.assert_array_equal(normalized[0], np.array([0.0, 0.0, 0.0]))
+
+    # Check non-zero vector is normalized
+    np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))


### PR DESCRIPTION
**🎯 What:**
Added unit tests for the `normalize_l2` function in `packages/code-index/src/affine/code_index/embedder.py`.

**📊 Coverage:**
Tested the function's handling of standard floating-point vector arrays (making sure their calculated shapes remain identical and their mathematical magnitude normalizes accurately to 1 via L2 computation). Also rigorously covered the edge case of vectors having zero magnitudes (where magnitude is 0) to ensure division by zero behaves correctly due to the `np.where(norms == 0, 1, norms)` handling gracefully outputting a zero vector array.

**✨ Result:**
The `normalize_l2` helper now possesses deterministic regression tests mapping mathematically verifiable inputs to known matrix representations. Test suite properly spans error-proof branches ensuring data-safe math transformations against NaN values.

---
*PR created automatically by Jules for task [3945039771717306882](https://jules.google.com/task/3945039771717306882) started by @Ven0m0*