### PR TITLE
🧪 Improve normalize_l2 testing and fix axis dimension

### DIFF
--- a/packages/code-index/src/affine/code_index/embedder.py
+++ b/packages/code-index/src/affine/code_index/embedder.py
@@ -29,7 +29,7 @@ class Embedder(Protocol):
 
 def normalize_l2(vectors: np.ndarray) -> np.ndarray:
     """L2 normalize vectors along last axis."""
-    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms = np.linalg.norm(vectors, axis=-1, keepdims=True)
     norms = np.where(norms == 0, 1, norms)
     return vectors / norms
 

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -29,3 +29,46 @@ def test_normalize_l2_zero_vector():
 
     # Check non-zero vector is normalized
     np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))
+
+def test_normalize_l2_1d_vector():
+    # Test with 1D vector
+    vector = np.array([3.0, 4.0])
+    normalized = normalize_l2(vector)
+
+    # Check shape
+    assert normalized.shape == vector.shape
+
+    # Check that norm is 1
+    norm = np.linalg.norm(normalized, axis=-1)
+    np.testing.assert_allclose(norm, 1.0, rtol=1e-5)
+
+    # Check specific values
+    expected = np.array([0.6, 0.8])
+    np.testing.assert_allclose(normalized, expected, rtol=1e-5)
+
+
+def test_normalize_l2_3d_vector():
+    # Test with 3D vector (e.g. batch of batches)
+    vectors = np.array([[[3.0, 4.0], [0.0, 5.0]], [[1.0, 1.0], [0.0, 0.0]]])
+    normalized = normalize_l2(vectors)
+
+    # Check shape
+    assert normalized.shape == vectors.shape
+
+    # Check that non-zero norms are 1
+    norms = np.linalg.norm(normalized, axis=-1)
+    expected_norms = np.array([[1.0, 1.0], [1.0, 0.0]])
+    np.testing.assert_allclose(norms, expected_norms, rtol=1e-5)
+
+    # Check specific values
+    expected = np.array([[[0.6, 0.8], [0.0, 1.0]], [[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.0, 0.0]]])
+    np.testing.assert_allclose(normalized, expected, rtol=1e-5)
+
+
+def test_normalize_l2_empty():
+    # Test with empty vector
+    empty_1d = np.array([])
+    empty_2d = np.array([[]])
+
+    assert normalize_l2(empty_1d).shape == empty_1d.shape
+    assert normalize_l2(empty_2d).shape == empty_2d.shape

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -30,6 +30,7 @@ def test_normalize_l2_zero_vector():
     # Check non-zero vector is normalized
     np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))
 
+
 def test_normalize_l2_1d_vector():
     # Test with 1D vector
     vector = np.array([3.0, 4.0])
@@ -61,7 +62,9 @@ def test_normalize_l2_3d_vector():
     np.testing.assert_allclose(norms, expected_norms, rtol=1e-5)
 
     # Check specific values
-    expected = np.array([[[0.6, 0.8], [0.0, 1.0]], [[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.0, 0.0]]])
+    expected = np.array(
+        [[[0.6, 0.8], [0.0, 1.0]], [[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.0, 0.0]]]
+    )
     np.testing.assert_allclose(normalized, expected, rtol=1e-5)
 
 

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -30,7 +30,6 @@ def test_normalize_l2_zero_vector():
     # Check non-zero vector is normalized
     np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))
 
-
 def test_normalize_l2_1d_vector():
     # Test with 1D vector
     vector = np.array([3.0, 4.0])
@@ -62,9 +61,7 @@ def test_normalize_l2_3d_vector():
     np.testing.assert_allclose(norms, expected_norms, rtol=1e-5)
 
     # Check specific values
-    expected = np.array(
-        [[[0.6, 0.8], [0.0, 1.0]], [[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.0, 0.0]]]
-    )
+    expected = np.array([[[0.6, 0.8], [0.0, 1.0]], [[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.0, 0.0]]])
     np.testing.assert_allclose(normalized, expected, rtol=1e-5)
 
 


### PR DESCRIPTION
## 🎯 What

The `normalize_l2` function in `packages/code-index/src/affine/code_index/embedder.py` was under-tested and actually contained a subtle bug. While its docstring specified "L2 normalize vectors along last axis", its implementation hardcoded `axis=1`. This restricted it to strictly 2-dimensional (batch) vectors and would crash if passed 1D (single vector) arrays. 

This PR updates `normalize_l2` to use `axis=-1`, restoring its intended generic dimensionality, and adds robust unit testing.

## 📊 Coverage

The test suite now comprehensively verifies `normalize_l2` behavior across standard embedding dimensionality profiles:
*   **Standard 2D arrays:** (Pre-existing) Tests shape and specific normalized values.
*   **1D arrays:** Explicit tests added verifying `[3.0, 4.0]` correctly normalizes to `[0.6, 0.8]`.
*   **3D arrays:** Explicit tests added for nested batch configurations (e.g., shape `(2, 2, 2)`).
*   **Zero Vectors:** (Pre-existing) Ensures `[0.0, 0.0]` appropriately remains a zero vector instead of producing `NaN` via zero division.
*   **Empty Arrays:** Checks that vectors of size `0` cleanly bypass normalization without failing, preserving original empty dimensionality.

## ✨ Result

The `normalize_l2` utility is now reliably typed and tested against 1D, 2D, and 3D shapes. Complete edge cases are covered resulting in robust test coverage for this function and the embedding layer logic.

---
*PR created automatically by Jules for task [4751509982753405889](https://jules.google.com/task/4751509982753405889) started by @Ven0m0*