### PR TITLE
🧪 [testing improvement] Add tests and enhance 1D support for normalize_l2

### DIFF
--- a/packages/code-index/src/affine/code_index/embedder.py
+++ b/packages/code-index/src/affine/code_index/embedder.py
@@ -29,7 +29,7 @@ class Embedder(Protocol):
 
 def normalize_l2(vectors: np.ndarray) -> np.ndarray:
     """L2 normalize vectors along last axis."""
-    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms = np.linalg.norm(vectors, axis=-1, keepdims=True)
     norms = np.where(norms == 0, 1, norms)
     return vectors / norms
 

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -30,6 +30,7 @@ def test_normalize_l2_zero_vector():
     # Check non-zero vector is normalized
     np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))
 
+
 def test_normalize_l2_1d():
     # Test with standard 1D vector
     vector = np.array([3.0, 4.0])

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -30,7 +30,6 @@ def test_normalize_l2_zero_vector():
     # Check non-zero vector is normalized
     np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))
 
-
 def test_normalize_l2_1d():
     # Test with standard 1D vector
     vector = np.array([3.0, 4.0])

--- a/packages/code-index/tests/test_embedder.py
+++ b/packages/code-index/tests/test_embedder.py
@@ -29,3 +29,28 @@ def test_normalize_l2_zero_vector():
 
     # Check non-zero vector is normalized
     np.testing.assert_array_equal(normalized[1], np.array([1.0, 0.0, 0.0]))
+
+def test_normalize_l2_1d():
+    # Test with standard 1D vector
+    vector = np.array([3.0, 4.0])
+    normalized = normalize_l2(vector)
+
+    # Check shape
+    assert normalized.shape == vector.shape
+
+    # Check that norm is 1
+    norm = np.linalg.norm(normalized, axis=-1)
+    np.testing.assert_allclose(norm, 1.0, rtol=1e-5)
+
+    # Check specific values
+    expected = np.array([0.6, 0.8])
+    np.testing.assert_allclose(normalized, expected, rtol=1e-5)
+
+
+def test_normalize_l2_zero_vector_1d():
+    # Test with zero 1D vector
+    vector = np.array([0.0, 0.0, 0.0])
+    normalized = normalize_l2(vector)
+
+    # Check zero vector remains zero
+    np.testing.assert_array_equal(normalized, np.array([0.0, 0.0, 0.0]))


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `normalize_l2` within the `packages/code-index/src/affine/code_index/embedder.py` file, which previously lacked specific test coverage for 1D arrays and would actually fail when a 1D array was provided due to the hardcoded `axis=1`.
📊 **Coverage:**
- Added test coverage for standard 1D vector normalization in `packages/code-index/tests/test_embedder.py`.
- Added test coverage for handling 1D zero vectors to ensure division by zero is handled safely.
- Modified the original implementation of `normalize_l2` to use `axis=-1` instead of `axis=1`, robustly supporting normalization for both 1D and multi-dimensional inputs.
✨ **Result:** Improved overall test coverage and code reliability, preventing unexpected `AxisError`s if standard or zero 1D vectors are passed to the embedder's normalization routine.

---
*PR created automatically by Jules for task [6956756760166630764](https://jules.google.com/task/6956756760166630764) started by @Ven0m0*