### PR TITLE
🧹 Remove unused functions in ChatWidget

### DIFF
--- a/apps/web/src/components/ChatWidget.tsx
+++ b/apps/web/src/components/ChatWidget.tsx
@@ -60,7 +60,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({
   persistentChat: _persistentChat = true,
 }) => {
   const [isOpen, setIsOpen] = useState(autoOpen);
-  const [hasInteracted, setHasInteracted] = useState(false);
+  const [hasInteracted, _setHasInteracted] = useState(false);
   useStore();
 
   // Request notification permission
@@ -96,23 +96,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [minimizeOnOutsideClick, isOpen]);
 
-  const _handleOpen = () => {
-    setIsOpen(true);
-    setHasInteracted(true);
-  };
-
   const handleClose = () => {
     setIsOpen(false);
-  };
-
-  const _getPositionStyles = () => {
-    const positions = {
-      'bottom-right': { bottom: offset.y, right: offset.x },
-      'bottom-left': { bottom: offset.y, left: offset.x },
-      'top-right': { top: offset.y, right: offset.x },
-      'top-left': { top: offset.y, left: offset.x },
-    };
-    return positions[position];
   };
 
   const getThemeStyles = () => {


### PR DESCRIPTION
🎯 **What:** Removed the unused `_handleOpen` and `_getPositionStyles` functions from `apps/web/src/components/ChatWidget.tsx`. Additionally, prefixed the unused `setHasInteracted` variable with an underscore to satisfy Biome linting.

💡 **Why:** These functions were dead code abandoned during component development. Removing them decreases file size, eliminates internal clutter, and improves readability without altering functionality.

✅ **Verification:** Formatted and linted with `@biomejs/biome` and ran `bun run test` ensuring all 43 tests pass successfully.

✨ **Result:** Codebase health improved with cleaner component implementation.

---
*PR created automatically by Jules for task [17913234340050853787](https://jules.google.com/task/17913234340050853787) started by @Ven0m0*