### PR TITLE
🔒 Disallow wildcard '*' in CORS origins

### DIFF
--- a/apps/api/src/affine/api/server.py
+++ b/apps/api/src/affine/api/server.py
@@ -121,12 +121,10 @@ MODEL_CATALOG = [
     },
 ]
 
-allow_all_origins = "*" in settings.cors_allow_origins
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_allow_origins,
-    allow_credentials=not allow_all_origins,
+    allow_credentials=True,
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "Accept"],
 )

--- a/apps/api/tests/test_server.py
+++ b/apps/api/tests/test_server.py
@@ -409,6 +409,3 @@ def test_cors_middleware_configuration() -> None:
     # Assert that allow_credentials is True and origins match settings
     assert cors_middleware.kwargs["allow_credentials"] is True
     assert cors_middleware.kwargs["allow_origins"] == settings.cors_allow_origins
-
-
-

--- a/apps/api/tests/test_server.py
+++ b/apps/api/tests/test_server.py
@@ -399,37 +399,16 @@ def test_list_models_includes_gateway_presets(client_with_key: TestClient) -> No
 
 def test_cors_middleware_configuration() -> None:
     from fastapi.middleware.cors import CORSMiddleware
-    from affine.api.server import app, allow_all_origins
+    from affine.api.server import app
     from affine.config.settings import get_settings
 
     settings = get_settings()
 
     cors_middleware = next(m for m in app.user_middleware if m.cls == CORSMiddleware)
 
-    # Assert that if allow_all_origins is True, allow_credentials is False
-    # and vice-versa
-    expected_credentials = not allow_all_origins
-    assert cors_middleware.kwargs["allow_credentials"] == expected_credentials
+    # Assert that allow_credentials is True and origins match settings
+    assert cors_middleware.kwargs["allow_credentials"] is True
     assert cors_middleware.kwargs["allow_origins"] == settings.cors_allow_origins
 
 
-def test_cors_middleware_when_wildcard_configured() -> None:
-    from fastapi import FastAPI
-    from fastapi.middleware.cors import CORSMiddleware
 
-    app_test = FastAPI()
-    test_allow_origins = ["*", "http://localhost:3000"]
-    allow_all = "*" in test_allow_origins
-
-    app_test.add_middleware(
-        CORSMiddleware,
-        allow_origins=test_allow_origins,
-        allow_credentials=not allow_all,
-        allow_methods=["GET", "POST", "OPTIONS"],
-        allow_headers=["Authorization", "Content-Type", "Accept"],
-    )
-
-    cors_middleware = next(
-        m for m in app_test.user_middleware if m.cls == CORSMiddleware
-    )
-    assert cors_middleware.kwargs["allow_credentials"] is False

--- a/packages/config/src/affine/config/settings.py
+++ b/packages/config/src/affine/config/settings.py
@@ -49,12 +49,16 @@ class Settings(BaseSettings):
             if not all(isinstance(origin, str) for origin in value):
                 raise ValueError("CORS origins must be strings.")
             origins = [origin.strip() for origin in value if origin.strip()]
+            if "*" in origins:
+                raise ValueError("Wildcard '*' is not allowed in CORS origins.")
             return origins
 
         if not isinstance(value, str):
             return value
 
         origins = [origin.strip() for origin in value.split(",") if origin.strip()]
+        if "*" in origins:
+            raise ValueError("Wildcard '*' is not allowed in CORS origins.")
         return origins
 
     def provider_api_key(self) -> str | None:

--- a/packages/config/tests/test_settings.py
+++ b/packages/config/tests/test_settings.py
@@ -121,11 +121,17 @@ def test_get_settings_env_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_settings_wildcard_cors_origin_rejected() -> None:
-    with pytest.raises(ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"):
+    with pytest.raises(
+        ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"
+    ):
         Settings(cors_allow_origins=["*"])
 
-    with pytest.raises(ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"):
+    with pytest.raises(
+        ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"
+    ):
         Settings(cors_allow_origins="*")
 
-    with pytest.raises(ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"):
+    with pytest.raises(
+        ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"
+    ):
         Settings(cors_allow_origins="http://localhost:3000, *")

--- a/packages/config/tests/test_settings.py
+++ b/packages/config/tests/test_settings.py
@@ -118,3 +118,14 @@ def test_get_settings_env_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Clean up cache at the end to avoid polluting other tests
     get_settings.cache_clear()
+
+
+def test_settings_wildcard_cors_origin_rejected() -> None:
+    with pytest.raises(ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"):
+        Settings(cors_allow_origins=["*"])
+
+    with pytest.raises(ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"):
+        Settings(cors_allow_origins="*")
+
+    with pytest.raises(ValueError, match=r"Wildcard '\*' is not allowed in CORS origins"):
+        Settings(cors_allow_origins="http://localhost:3000, *")


### PR DESCRIPTION
🎯 What:
Added validation to settings.cors_allow_origins to explicitly reject the wildcard '*' character.
Removed the allow_all_origins logic from the FastAPI CORSMiddleware setup, as wildcards are now impossible.
Hardcoded allow_credentials=True in the CORSMiddleware, which is safe since '*' is blocked.
Updated and added tests to enforce this behavior.

⚠️ Risk:
Allowing '*' in allow_origins while allow_credentials is True (or effectively enabled due to misconfiguration) creates an overly permissive CORS policy. This could allow malicious websites to make cross-origin requests on behalf of an authenticated user, leading to data exfiltration or unauthorized actions (CSRF-like attacks).

🛡️ Solution:
By strictly disallowing '*' at the configuration level, the application will fail to start if misconfigured, enforcing a 'secure by default' posture. Since '*' is blocked, allow_credentials=True can be safely enabled for all valid, explicitly allowed origins.

---
*PR created automatically by Jules for task [12988008794020062356](https://jules.google.com/task/12988008794020062356) started by @Ven0m0*