### PR TITLE
🧪 Add tests for wrapError utility

### DIFF
--- a/apps/web/src/utils/error.test.ts
+++ b/apps/web/src/utils/error.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { wrapError } from './error';
+
+describe('wrapError', () => {
+  it('should wrap an Error instance correctly', () => {
+    const originalError = new Error('Original error message');
+    const wrappedError = wrapError('do something', originalError);
+
+    expect(wrappedError).toBeInstanceOf(Error);
+    expect(wrappedError.message).toBe('Failed to do something: Original error message');
+    expect(wrappedError.cause).toBe(originalError);
+  });
+
+  it('should wrap a string correctly', () => {
+    const originalError = 'String error message';
+    const wrappedError = wrapError('do something', originalError);
+
+    expect(wrappedError).toBeInstanceOf(Error);
+    expect(wrappedError.message).toBe('Failed to do something: String error message');
+    expect(wrappedError.cause).toBe(originalError);
+  });
+
+  it('should wrap an object correctly', () => {
+    const originalError = { foo: 'bar' };
+    const wrappedError = wrapError('do something', originalError);
+
+    expect(wrappedError).toBeInstanceOf(Error);
+    expect(wrappedError.message).toBe('Failed to do something: [object Object]');
+    expect(wrappedError.cause).toBe(originalError);
+  });
+
+  it('should wrap null correctly', () => {
+    const originalError = null;
+    const wrappedError = wrapError('do something', originalError);
+
+    expect(wrappedError).toBeInstanceOf(Error);
+    expect(wrappedError.message).toBe('Failed to do something: null');
+    expect(wrappedError.cause).toBe(originalError);
+  });
+
+  it('should wrap undefined correctly', () => {
+    const originalError = undefined;
+    const wrappedError = wrapError('do something', originalError);
+
+    expect(wrappedError).toBeInstanceOf(Error);
+    expect(wrappedError.message).toBe('Failed to do something: undefined');
+    expect(wrappedError.cause).toBe(originalError);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `wrapError` utility in `apps/web/src/utils/error.ts`.
📊 **Coverage:** Covered all cases for the `error` argument, including an `Error` instance, strings, objects, `null`, and `undefined`. Verified correct assignment of `message` and `cause` properties.
✨ **Result:** Improved overall test coverage and reliability for error handling utilities.

---
*PR created automatically by Jules for task [1895788693465142608](https://jules.google.com/task/1895788693465142608) started by @Ven0m0*