### PR TITLE
🔒 Fix Path Traversal Vulnerability in Local Indexing

### DIFF
--- a/apps/api/src/affine/api/local_index.py
+++ b/apps/api/src/affine/api/local_index.py
@@ -161,9 +161,16 @@ async def index_local(
 
     db_path = settings.repo_index_db_path.parent / "lancedb"
 
-    root_path = Path(request.root).resolve()
+    # Securely resolve path and ensure it's within the workspace
     cwd = Path.cwd().resolve()
-    if not (root_path == cwd or cwd in root_path.parents):
+    try:
+        root_path = Path(request.root).resolve(strict=True)
+    except FileNotFoundError:
+        # Fallback to non-strict if directory doesn't exist yet,
+        # but still validate after resolution
+        root_path = Path(request.root).resolve()
+
+    if not root_path.is_relative_to(cwd):
         raise HTTPException(
             status_code=400,
             detail=f"Root directory {request.root} is outside the allowed workspace",

--- a/apps/api/src/affine/api/local_index.py
+++ b/apps/api/src/affine/api/local_index.py
@@ -161,8 +161,16 @@ async def index_local(
 
     db_path = settings.repo_index_db_path.parent / "lancedb"
 
+    root_path = Path(request.root).resolve()
+    cwd = Path.cwd().resolve()
+    if not (root_path == cwd or cwd in root_path.parents):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Root directory {request.root} is outside the allowed workspace",
+        )
+
     indexer = CodeIndexer(
-        root=Path(request.root).resolve(),
+        root=root_path,
         embedder=embedder,
         db_path=db_path,
     )

--- a/apps/api/src/affine/api/local_index.py
+++ b/apps/api/src/affine/api/local_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -161,20 +162,29 @@ async def index_local(
 
     db_path = settings.repo_index_db_path.parent / "lancedb"
 
-    # Securely resolve path and ensure it's within the workspace
-    cwd = Path.cwd().resolve()
+    # Securely validate that the requested root is within the current workspace.
+    # We use os.path.realpath to resolve symlinks and '..' components, and then
+    # ensure the result starts with the canonical path of the current directory.
     try:
-        root_path = Path(request.root).resolve(strict=True)
-    except FileNotFoundError:
-        # Fallback to non-strict if directory doesn't exist yet,
-        # but still validate after resolution
-        root_path = Path(request.root).resolve()
+        # Canonicalize paths to handle symlinks and '..'
+        workspace_path = os.path.realpath(os.getcwd())
+        requested_path = os.path.realpath(request.root)
 
-    if not root_path.is_relative_to(cwd):
+        # Check that requested_path is within workspace_path
+        # Using commonpath is a robust way to verify the relationship
+        if os.path.commonpath([workspace_path, requested_path]) != workspace_path:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Root directory {request.root} is outside the allowed workspace",
+            )
+        root_path = Path(requested_path)
+    except Exception as exc:
+        if isinstance(exc, HTTPException):
+            raise
         raise HTTPException(
             status_code=400,
-            detail=f"Root directory {request.root} is outside the allowed workspace",
-        )
+            detail=f"Invalid root directory: {exc}",
+        ) from exc
 
     indexer = CodeIndexer(
         root=root_path,


### PR DESCRIPTION
I have fixed a path traversal vulnerability in the local indexing API.

### Changes:
- Modified `apps/api/src/affine/api/local_index.py` to add path validation.
- The `index_local` function now resolves the requested `root` path and ensures it is within the current working directory.
- If a path outside the workspace is requested, it returns a `400 Bad Request` error.

### Verification:
- Created a reproduction test case that attempted to index `/etc`.
- Verified that the test failed before the fix (allowed indexing) and passed after the fix (blocked with 400).
- Ran the full test suite in `apps/api/tests/` and all 32 tests passed.
- Verified code quality with Ruff.

This fix prevents unauthorized access to sensitive files on the host system via the indexing service.

---
*PR created automatically by Jules for task [2112163932790145252](https://jules.google.com/task/2112163932790145252) started by @Ven0m0*