### PR TITLE
🧹 Remove unused isBuiltinProvider function in providers service

### DIFF
--- a/apps/web/src/services/providers.ts
+++ b/apps/web/src/services/providers.ts
@@ -314,6 +314,3 @@ export function migrateSavedConfig<T extends { provider?: string; model?: string
   return migrated;
 }
 
-export function isBuiltinProvider(providerId: string): boolean {
-  return BUILTIN_PROVIDER_DEFINITIONS.some((provider) => provider.id === providerId);
-}

--- a/apps/web/src/services/providers.ts
+++ b/apps/web/src/services/providers.ts
@@ -313,4 +313,3 @@ export function migrateSavedConfig<T extends { provider?: string; model?: string
   }
   return migrated;
 }
-


### PR DESCRIPTION
🎯 **What:** Removed the unused `isBuiltinProvider` exported function from `apps/web/src/services/providers.ts`.
💡 **Why:** This function was not used anywhere in the codebase. Removing it reduces dead code surface and improves maintainability.
✅ **Verification:** Verified that there are no references to `isBuiltinProvider` using `grep`. Ran `apps/web/src/services/providers.test.ts` and all 18 tests passed.
✨ **Result:** Reduced dead code in the providers service.

---
*PR created automatically by Jules for task [9690569229572722309](https://jules.google.com/task/9690569229572722309) started by @Ven0m0*