### PR TITLE
🧹 [code health] Replace pass with ... in abstract interface methods

### DIFF
--- a/packages/llm-core/src/affine/llm_core/interfaces.py
+++ b/packages/llm-core/src/affine/llm_core/interfaces.py
@@ -8,8 +8,7 @@ from affine.shared.models import TextMessage
 class LLMProvider(ABC):
     @property
     @abstractmethod
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
     @abstractmethod
     async def generate(
@@ -19,8 +18,7 @@ class LLMProvider(ABC):
         system: str | None = None,
         history: list[TextMessage] | None = None,
         **kwargs: Any,
-    ) -> str:
-        ...
+    ) -> str: ...
 
     @abstractmethod
     def stream(
@@ -30,8 +28,6 @@ class LLMProvider(ABC):
         system: str | None = None,
         history: list[TextMessage] | None = None,
         **kwargs: Any,
-    ) -> AsyncIterator[str]:
-        ...
+    ) -> AsyncIterator[str]: ...
 
-    async def aclose(self) -> None:
-        ...
+    async def aclose(self) -> None: ...

--- a/packages/llm-core/src/affine/llm_core/interfaces.py
+++ b/packages/llm-core/src/affine/llm_core/interfaces.py
@@ -9,7 +9,7 @@ class LLMProvider(ABC):
     @property
     @abstractmethod
     def name(self) -> str:
-        pass
+        ...
 
     @abstractmethod
     async def generate(
@@ -20,7 +20,7 @@ class LLMProvider(ABC):
         history: list[TextMessage] | None = None,
         **kwargs: Any,
     ) -> str:
-        pass
+        ...
 
     @abstractmethod
     def stream(
@@ -31,7 +31,7 @@ class LLMProvider(ABC):
         history: list[TextMessage] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[str]:
-        pass
+        ...
 
     async def aclose(self) -> None:
-        pass
+        ...


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced `pass` statements with `...` in the `LLMProvider` abstract base class methods within `packages/llm-core/src/affine/llm_core/interfaces.py`.

💡 **Why:** How this improves maintainability
Using an ellipsis (`...`) is the Pythonic standard for stub/interface methods, improving semantic correctness and readability compared to using `pass`.

✅ **Verification:** How you confirmed the change is safe
Ran the full test suite (`uv run pytest`) and verified no regressions were introduced.

✨ **Result:** The improvement achieved
Cleaner, more semantically correct interface definition.

---
*PR created automatically by Jules for task [18279576091839929723](https://jules.google.com/task/18279576091839929723) started by @Ven0m0*