### PR TITLE
🧹 Add explanatory comment to empty aclose method in LocalEmbedder

### DIFF
--- a/packages/code-index/src/affine/code_index/embedder.py
+++ b/packages/code-index/src/affine/code_index/embedder.py
@@ -312,6 +312,8 @@ class LocalEmbedder:
         return all_vectors
 
     async def aclose(self) -> None:
+        """Close any resources."""
+        # Local models do not use network clients or async resources requiring cleanup
         pass
 
     def _load_model(self):


### PR DESCRIPTION
🎯 **What:** Added an explanatory comment to the empty `aclose` method in `packages/code-index/src/affine/code_index/embedder.py`.

💡 **Why:** `LocalEmbedder` does not use network clients or async resources that require explicit cleanup. The comment clarifies why the method is intentionally left empty with `pass`, fulfilling code health guidelines.

✅ **Verification:** 
- Ran `uv run ruff check` and `uv run ruff format` to ensure code style compliance. 
- Ran `uv run pytest packages/code-index` and `uv run pytest packages/code-index/tests/test_embedder.py` to confirm no functionality was broken.

✨ **Result:** Improved codebase maintainability by explicitly documenting the reason for a no-op concrete method.

---
*PR created automatically by Jules for task [2915654542108613726](https://jules.google.com/task/2915654542108613726) started by @Ven0m0*